### PR TITLE
Hide 'common' header and refactor grouping code

### DIFF
--- a/src/components/DisplayList/DisplayList.tsx
+++ b/src/components/DisplayList/DisplayList.tsx
@@ -5,7 +5,7 @@ import ListSubheader from '@mui/material/ListSubheader';
 import Checkbox from '@mui/material/Checkbox';
 import { setLayout } from '../../slices/layoutSlice';
 import { selectSelectedRelDisps, setSelectedRelDisps } from '../../slices/selectedRelDispsSlice';
-import { useDisplayGroups, commonTagsKey } from '../../slices/displayListAPI';
+import { useDisplayGroups } from '../../slices/displayListAPI';
 import { selectBasePath } from '../../slices/appSlice';
 import styles from './DisplayList.module.scss';
 
@@ -21,7 +21,8 @@ const DisplayList: React.FC<DisplayListProps> = ({ selectable, displayItems, han
   const selectedRelDisps = useSelector(selectSelectedRelDisps);
   const basePath = useSelector(selectBasePath);
   const displayGroups = useDisplayGroups(excludedDisplays);
-  const groupKeys = Object.keys(displayGroups);
+
+  const groupKeys = Array.from(displayGroups.keys());
 
   const handleCheckbox = (i: number) => {
     const checked = selectedRelDisps.indexOf(i) > -1;
@@ -50,16 +51,16 @@ const DisplayList: React.FC<DisplayListProps> = ({ selectable, displayItems, han
   return (
     <div className={styles.displayListContainer}>
       {groupKeys.map((groupName) => (
-        <div className={styles.displayListGroupContainer} key={groupName}>
+        <div className={styles.displayListGroupContainer} key={groupName.toString()}>
           <ImageList rowHeight={180} cols={3} className={styles.displayListGridList}>
             {groupKeys.length > 1 ? (
               <ImageListItem key="Subheader" cols={3} style={{ height: 'auto' }}>
                 <ListSubheader style={{ fontSize: 20, color: 'black' }} component="div">
-                  {groupName === commonTagsKey ? '' : groupName}
+                  {typeof groupName === 'symbol' ? '' : groupName}
                 </ListSubheader>
               </ImageListItem>
             ) : null}
-            {displayGroups[groupName].map((i: number) => (
+            {displayGroups.get(groupName)?.map((i: number) => (
               <ImageListItem
                 key={i}
                 className={styles.displayListGridTile}

--- a/src/components/SidebarFilter/FilterList/FilterList.tsx
+++ b/src/components/SidebarFilter/FilterList/FilterList.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
-import { commonTagsKey, setFilterView, useInactiveFilterGroups } from '../../../slices/filterSlice';
+import { useDispatch, useSelector } from 'react-redux';
+import { COMMON_TAGS_KEY } from '../../../constants';
+import { useMetaGroups } from '../../../slices/displayInfoAPI';
+import { selectInactiveFilterView, setFilterView } from '../../../slices/filterSlice';
 import Pill from '../../Pill';
 
 import styles from './FilterList.module.scss';
 
 const FilterList: React.FC = () => {
-  const inactiveFilterGroups = useInactiveFilterGroups();
+  const inactiveFilters = useSelector(selectInactiveFilterView);
+  const inactiveFilterGroups = useMetaGroups(inactiveFilters);
+
   const dispatch = useDispatch();
 
   const handleClick = (filter: string) => {
@@ -16,15 +20,17 @@ const FilterList: React.FC = () => {
   return (
     <div className={styles.filterList}>
       <div className={styles.filterListHeading}>Select a variable to filter on:</div>
-      {Object.keys(inactiveFilterGroups).map((key) => (
-        <div className={styles.filterListGroup} key={key}>
-          {key !== commonTagsKey && (
+      {Array.from(inactiveFilterGroups.keys()).map((key) => (
+        <div className={styles.filterListGroup} key={key.toString()}>
+          {key !== COMMON_TAGS_KEY && (
             <div className={styles.filterListGroupHeader}>
-              {key} ({inactiveFilterGroups[key].length})
+              <>
+                {key} ({inactiveFilterGroups?.get(key)?.length})
+              </>
             </div>
           )}
           <ul className={styles.filterListItems}>
-            {inactiveFilterGroups[key].map((filter) => (
+            {inactiveFilterGroups?.get(key)?.map((filter) => (
               <Pill key={filter} onClick={() => handleClick(filter)}>
                 {filter}
               </Pill>

--- a/src/components/SidebarLabels/SidebarLabels.tsx
+++ b/src/components/SidebarLabels/SidebarLabels.tsx
@@ -3,15 +3,17 @@ import List from '@mui/material/List';
 import ListSubheader from '@mui/material/ListSubheader';
 import { useDispatch, useSelector } from 'react-redux';
 import SidebarLabelPill from '../SidebarLabelPill';
-import { useDisplayMetasWithInputs, useMetaGroupsWithInputsSorted } from '../../slices/displayInfoAPI';
+import { useDisplayMetasWithInputs, useMetaGroupsWithInputs } from '../../slices/displayInfoAPI';
 import { labelsSelector } from '../../selectors';
 import styles from './SidebarLabels.module.scss';
 import { setLabels } from '../../slices/labelsSlice';
+import { COMMON_TAGS_KEY } from '../../constants';
 
 const SidebarLabels: React.FC = () => {
   const dispatch = useDispatch();
   const labels = useSelector(labelsSelector);
-  const labelObj = useMetaGroupsWithInputsSorted() as { [key: string]: string[] };
+  const labelObj = useMetaGroupsWithInputs();
+
   const metasWithInputs = useDisplayMetasWithInputs();
   const labelDescriptionMap = new Map();
   metasWithInputs.forEach((meta) => {
@@ -34,27 +36,32 @@ const SidebarLabels: React.FC = () => {
       {labelDescriptionMap.size > 0 && (
         <div className={styles.sidebarLabels}>
           <List className={styles.sidebarLabelsList}>
-            {Object.keys(labelObj).map((grp) => {
-              const curItems = labelObj[grp];
+            {Array.from(labelObj.keys()).map((grp) => {
+              const groupString = grp.toString();
+              const curItems = labelObj.get(grp);
               if (curItems?.length === 0 || !curItems) {
                 return null;
               }
               return (
-                <React.Fragment key={grp}>
-                  {!['condVar', 'common', 'panelKey'].includes(grp) && (
+                <React.Fragment key={groupString}>
+                  {/* Don't include header for non-tagged group */}
+                  {grp !== COMMON_TAGS_KEY && (
                     <ListSubheader className={styles.sidebarLabelsCogGroupHeader}>
-                      <span className={styles.sidebarLabelsCogGroupText}>{`${grp} (${curItems.length})`}</span>
+                      <span className={styles.sidebarLabelsCogGroupText}>{`${groupString} (${curItems.length})`}</span>
                     </ListSubheader>
                   )}
-                  {[...labelObj[grp]].sort().map((label: string) => (
-                    <SidebarLabelPill
-                      labels={labels}
-                      labelDescriptionMap={labelDescriptionMap}
-                      label={label}
-                      handleLabelChange={handleLabelChange}
-                      key={`${label}_${grp}`}
-                    />
-                  ))}
+                  {labelObj
+                    ?.get(grp)
+                    ?.sort()
+                    .map((label: string) => (
+                      <SidebarLabelPill
+                        labels={labels}
+                        labelDescriptionMap={labelDescriptionMap}
+                        label={label}
+                        handleLabelChange={handleLabelChange}
+                        key={`${label}_${groupString}`}
+                      />
+                    ))}
                 </React.Fragment>
               );
             })}

--- a/src/components/SidebarSort/SidebarSort.tsx
+++ b/src/components/SidebarSort/SidebarSort.tsx
@@ -13,7 +13,7 @@ import styles from './SidebarSort.module.scss';
 const SidebarSort: React.FC = () => {
   const sort = useSelector(selectSort);
   const sort2 = Object.assign([], sort) as ISortState[];
-  const metaGroups = useMetaGroups() || {};
+  const metaGroups = useMetaGroups();
   const labels = useSelector(labelsSelector);
   const metaLabels = useDisplayMetasLabels();
   const sidebarHeight = useSelector(sidebarHeightSelector);

--- a/src/components/SidebarSortPill/SidebarSortPill.tsx
+++ b/src/components/SidebarSortPill/SidebarSortPill.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import styles from './SidebarSortPill.module.scss';
+import { COMMON_TAGS_KEY } from '../../constants';
 
 interface SidebarSortPillProps {
-  metaGroups: { [key: string | symbol]: string[] };
+  metaGroups: Map<string | symbol, string[]>;
   sidebarHeight: number;
   activeHeight: number;
   addSortLabel: (name: string) => void;
@@ -34,19 +35,20 @@ const SidebarSortPill: React.FC<SidebarSortPillProps> = ({
   return (
     <div className={styles.sidebarSortPill}>
       <div className={styles.sidebarSortPillNotUsed} style={customStyles.notUsed}>
-        {Object.keys(metaGroups).map((grp) => {
-          const curItems = metaGroups[grp].filter((d) => !activeSorts.includes(d));
-          if (curItems.length === 0) {
+        {Array.from(metaGroups.keys()).map((grp) => {
+          const groupString = grp.toString();
+          const curItems = metaGroups?.get(grp)?.filter((d) => !activeSorts.includes(d));
+          if (curItems?.length === 0) {
             return null;
           }
           return (
-            <React.Fragment key={grp}>
-              {!['condVar', '__common__', 'panelKey'].includes(grp) && (
+            <React.Fragment key={groupString}>
+              {grp !== COMMON_TAGS_KEY && (
                 <div className={styles.sidebarSortPillCogGroupHeader}>
-                  <span className={styles.sidebarSortPillCogGroupText}>{`${grp} (${curItems.length})`}</span>
+                  <span className={styles.sidebarSortPillCogGroupText}>{`${groupString} (${curItems?.length})`}</span>
                 </div>
               )}
-              {curItems.sort().map((d: string) => (
+              {curItems?.sort().map((d: string) => (
                 <Tooltip
                   title={metaLabels[d]}
                   placement="right"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,3 +42,6 @@ export const META_FILTER_TYPE_MAP = {
 };
 
 export const PANEL_KEY = '__PANEL_KEY__' as string;
+
+// Symbol to use as a key for common tags to avoid collisions with user-defined tags
+export const COMMON_TAGS_KEY = Symbol('__common__') as symbol;

--- a/src/slices/displayListAPI.ts
+++ b/src/slices/displayListAPI.ts
@@ -1,6 +1,7 @@
 import { BaseQueryFn, createApi } from '@reduxjs/toolkit/query/react';
 import getJSONP from 'browser-jsonp';
 import { useSelector } from 'react-redux';
+import { COMMON_TAGS_KEY } from '../constants';
 import { selectAppId, selectBasePath } from './appSlice';
 import { useDataType } from './configAPI';
 import { selectSelectedRelDisps } from './selectedRelDispsSlice';
@@ -59,27 +60,23 @@ export const useRelatedDisplayNames = () => {
   return relDispNames;
 };
 
-export const commonTagsKey = '__common__';
 export const useDisplayGroups = (excluded: string[] = []) => {
   const { data: displays = [] } = useDisplayList();
 
-  return displays.reduce<{ [index: string | symbol]: number[] }>(
-    (acc, display, index) => {
-      const tags = display.tags || [];
-      if (tags.length === 0 && !excluded.includes(display.name)) {
-        acc[commonTagsKey].push(index);
-        return acc;
-      }
-      tags.forEach((tag) => {
-        if (!excluded.includes(display.name)) {
-          if (!acc[tag]) {
-            acc[tag] = [];
-          }
-          acc[tag].push(index);
-        }
-      });
+  return displays.reduce((acc, display, index) => {
+    const tags = display.tags || [];
+    if (tags.length === 0 && !excluded.includes(display.name)) {
+      acc.get(COMMON_TAGS_KEY)?.push(index);
       return acc;
-    },
-    { [commonTagsKey]: [] },
-  );
+    }
+    tags.forEach((tag) => {
+      if (!excluded.includes(display.name)) {
+        if (!acc.has(tag)) {
+          acc.set(tag, []);
+        }
+        acc.get(tag)?.push(index);
+      }
+    });
+    return acc;
+  }, new Map<string | symbol, number[]>([[COMMON_TAGS_KEY, []]]));
 };

--- a/src/slices/filterSlice.ts
+++ b/src/slices/filterSlice.ts
@@ -1,9 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import difference from 'lodash.difference';
-import { useSelector } from 'react-redux';
 import type { RootState } from '../store';
-import { displayInfoAPI, useDisplayMetas } from './displayInfoAPI';
+import { displayInfoAPI } from './displayInfoAPI';
 import { selectHashFilters, selectHashFilterView } from '../selectors/hash';
 
 export interface FilterState {
@@ -133,32 +132,5 @@ export const selectFilterByVarname = (varname: string) => (state: RootState) =>
 export const selectFilterView = (state: RootState) => state.filter.view;
 
 export const selectInactiveFilterView = (state: RootState) => state.filter.view.inactive;
-
-// TODO: see if we can share code with the other one
-export const commonTagsKey = '__common__';
-export const useInactiveFilterGroups = () => {
-  const metas = useDisplayMetas();
-  const inactiveFilters = useSelector(selectInactiveFilterView);
-
-  return metas.reduce<{ [index: string | symbol]: string[] }>(
-    (acc, meta) => {
-      const tags = meta.tags || [];
-      if (tags.length === 0 && inactiveFilters.includes(meta.varname) && meta.filterable) {
-        acc[commonTagsKey].push(meta.varname);
-        return acc;
-      }
-      tags.forEach((tag) => {
-        if (!acc[tag]) {
-          acc[tag] = [];
-        }
-        if (inactiveFilters.includes(meta.varname) && meta.filterable) {
-          acc[tag].push(meta.varname);
-        }
-      });
-      return acc;
-    },
-    { [commonTagsKey]: [] },
-  );
-};
 
 export default filterSlice.reducer;


### PR DESCRIPTION
- Changes `__common__` string to a javascript symbol to avoid user naming collisions.
- This necessitates using Maps instead of Objects to retain sort order because symbols are always ordered last.