### PR TITLE
Fix panel aspect ratio on safari, make images preserve original aspec…

### DIFF
--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -64,6 +64,7 @@ const Content: React.FC = () => {
                 {names.map((name) => (
                   <PanelGraphic
                     type={displayInfo?.paneltype}
+                    ncol={layout.ncol}
                     src={getPanelSrc(d, name).toString()}
                     alt={name}
                     aspectRatio={displayInfo?.panelaspect}

--- a/src/components/Panel/Panel.module.scss
+++ b/src/components/Panel/Panel.module.scss
@@ -9,6 +9,7 @@
     flex-grow: 1;
 
     img {
+      object-fit: contain;
       max-width: 100%;
       min-width: 1px;
       width: 100%;

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -11,7 +11,7 @@ interface PanelProps {
 
 const Panel: React.FC<PanelProps> = ({ data, labels, inputs, children }) => (
   <div className={styles.panel}>
-    <div className={styles.panelGraphic}>{children}</div>
+    {children}
     <PanelTable data={data} labels={labels} inputs={inputs} />
   </div>
 );

--- a/src/components/Panel/PanelGraphic.tsx
+++ b/src/components/Panel/PanelGraphic.tsx
@@ -5,13 +5,14 @@ interface PanelGraphicProps {
   type: PanelType;
   src: string;
   alt: string;
+  ncol: number;
   aspectRatio?: number;
 }
 
-const PanelGraphic: React.FC<PanelGraphicProps> = ({ type, src, alt, aspectRatio }) => (
+const PanelGraphic: React.FC<PanelGraphicProps> = ({ type, src, alt, ncol, aspectRatio }) => (
   <div className={styles.panelGraphic} style={{ aspectRatio }}>
-    {type === 'iframe' && <iframe width="100%" height="100%" scrolling="no" src={src} title={alt} />}
-    {type === 'img' && <img src={src} alt={alt} />}
+    {type === 'iframe' && <iframe key={`${ncol}_${window.innerWidth}`} width="100%" height="100%" scrolling="no" src={src} title={alt} />}
+    {type === 'img' && <img style={{ objectFit: 'contain' }} src={src} alt={alt} />}
   </div>
 );
 

--- a/src/components/Panel/PanelGraphic.tsx
+++ b/src/components/Panel/PanelGraphic.tsx
@@ -11,8 +11,10 @@ interface PanelGraphicProps {
 
 const PanelGraphic: React.FC<PanelGraphicProps> = ({ type, src, alt, ncol, aspectRatio }) => (
   <div className={styles.panelGraphic} style={{ aspectRatio }}>
-    {type === 'iframe' && <iframe key={`${ncol}_${window.innerWidth}`} width="100%" height="100%" scrolling="no" src={src} title={alt} />}
-    {type === 'img' && <img style={{ objectFit: 'contain' }} src={src} alt={alt} />}
+    {type === 'iframe' && (
+      <iframe key={`${ncol}_${window.innerWidth}`} width="100%" height="100%" scrolling="no" src={src} title={alt} />
+    )}
+    {type === 'img' && <img src={src} alt={alt} />}
   </div>
 );
 


### PR DESCRIPTION
Fix panel aspect ratio on safari, make images preserve original aspect ratio, force iframe reload on ncol or dimensions change.

This fixes #741, #720, #716.

The issue with Safari is that we were rendering two PanelGraphic divs inside each other, with the inner one have aspect ratio defined. Safari was not honoring this. I removed the redundant PanelGraphic.

I also added a key to the iframe that contains the number of columns and the window width. This will force the iframe to re-render whenever the number of columns or size of the window changes, which we need because often the visuals inside the iframes are not aware of these changes and do not adapt.

I also added `object-fit: contain` to the img tags so that regardless of our panel aspect ratio, the images that show up inside (which could have varying aspect ratios) render correctly.